### PR TITLE
Change `Teams` to `CodeTeams`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-See https://github.com/rubyatscale/bigrails-teams/releases
+See https://github.com/rubyatscale/code_teams/releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-See https://github.com/bigrails/bigrails-teams/releases
+See https://github.com/rubyatscale/bigrails-teams/releases

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bigrails-teams (0.1.1)
+    code_teams (0.1.1)
       sorbet-runtime
 
 GEM
@@ -47,7 +47,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bigrails-teams!
+  code_teams!
   pry
   rake
   rspec (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Teams
+# CodeTeams
 
-This gem is a simple, low-dependency, plugin-based manager for engineering teams within a codebase.
+This gem is a simple, low-dependency, plugin-based manager for teams within a codebase.
 
 ## Usage
 
-To use teams, add YML files in `config/teams` that start with structure:
+To use `code_teams`, add YML files in `config/teams` that start with structure:
 `config/teams/my_team.yml`
 ```yml
 name: My Team
 ```
 
-`teams` leverages a plugin system because every organization's team practices are different. Say your organization uses GitHub and wants to ensure every team YML files has a GitHub owner. To do this, you create a plugin:
+`code_teams` leverages a plugin system because every organization's team practices are different. Say your organization uses GitHub and wants to ensure every team YML files has a GitHub owner. To do this, you create a plugin:
 
 ```ruby
-class MyGithubPlugin < Teams::Plugin
+class MyGithubPlugin < CodeTeams::Plugin
   extend T::Sig
   extend T::Helpers
 
@@ -36,7 +36,7 @@ class MyGithubPlugin < Teams::Plugin
     members.include?(user)
   end
 
-  sig { override.params(teams: T::Array[Teams::Team]).returns(T::Array[String]) }
+  sig { override.params(teams: T::Array[CodeTeams::Team]).returns(T::Array[String]) }
   def self.validation_errors(teams)
     errors = T.let([], T::Array[String])
 
@@ -61,7 +61,7 @@ github:
 
 1) You can now use the following API to get GitHub information about that team:
 ```ruby
-team = Teams.find('My Team')
+team = CodeTeams.find('My Team')
 MyGithubPlugin.for(team).github
 ```
 2) Running team validations (see below) will ensure all teams have a GitHub team specified
@@ -76,8 +76,8 @@ Your plugins can be as simple or as complex as you want. Here are some other thi
 ## Configuration
 You'll want to ensure that all teams are valid in your CI environment. We recommend running code like this in CI:
 ```ruby
-require 'teams'
-errors = ::Teams.validation_errors(::Teams.all)
+require 'code_teams'
+errors = ::CodeTeams.validation_errors(::CodeTeams.all)
 if errors.any?
   abort <<~ERROR
     Team validation failed with the following errors:

--- a/lib/bigrails-teams.rb
+++ b/lib/bigrails-teams.rb
@@ -1,1 +1,0 @@
-require 'teams'

--- a/lib/code_teams.rb
+++ b/lib/code_teams.rb
@@ -6,10 +6,10 @@ require 'yaml'
 require 'set'
 require 'pathname'
 require 'sorbet-runtime'
-require 'teams/plugin'
-require 'teams/plugins/identity'
+require 'code_teams/plugin'
+require 'code_teams/plugins/identity'
 
-module Teams
+module CodeTeams
   extend T::Sig
 
   class IncorrectPublicApiUsageError < StandardError; end
@@ -24,7 +24,7 @@ module Teams
 
   sig { params(name: String).returns(T.nilable(Team)) }
   def self.find(name)
-    @index_by_name = T.let(@index_by_name, T.nilable(T::Hash[String, Teams::Team]))
+    @index_by_name = T.let(@index_by_name, T.nilable(T::Hash[String, CodeTeams::Team]))
     @index_by_name ||= begin
       result = {}
       all.each { |t| result[t.name] = t }
@@ -57,7 +57,7 @@ module Teams
 
   # Generally, you should not ever need to do this, because once your ruby process loads, cached content should not change.
   # Namely, the YML files that are the source of truth for teams should not change, so we should not need to look at the YMLs again to verify.
-  # The primary reason this is helpful is for clients of Teams who want to test their code, and each test context has different set of teams
+  # The primary reason this is helpful is for clients of CodeTeams who want to test their code, and each test context has different set of teams
   sig { void }
   def self.bust_caches!
     @all = nil
@@ -109,12 +109,12 @@ module Teams
 
     sig { returns(String) }
     def to_tag
-      Teams.tag_value_for(name)
+      CodeTeams.tag_value_for(name)
     end
 
     sig { params(other: Object).returns(T::Boolean) }
     def ==(other)
-      if other.is_a?(Teams::Team)
+      if other.is_a?(CodeTeams::Team)
         self.name == other.name
       else
         false

--- a/lib/code_teams/plugin.rb
+++ b/lib/code_teams/plugin.rb
@@ -1,6 +1,6 @@
 # typed: strict
 
-module Teams
+module CodeTeams
   # Plugins allow a client to add validation on custom keys in the team YML.
   # For now, only a single plugin is allowed to manage validation on a top-level key.
   # In the future we can think of allowing plugins to be gracefully merged with each other.

--- a/lib/code_teams/plugins/identity.rb
+++ b/lib/code_teams/plugins/identity.rb
@@ -1,6 +1,6 @@
 # typed: true
 
-module Teams
+module CodeTeams
   module Plugins
     class Identity < Plugin
       extend T::Sig
@@ -15,7 +15,7 @@ module Teams
         )
       end
 
-      sig { override.params(teams: T::Array[Teams::Team]).returns(T::Array[String]) }
+      sig { override.params(teams: T::Array[CodeTeams::Team]).returns(T::Array[String]) }
       def self.validation_errors(teams)
         errors = T.let([], T::Array[String])
 

--- a/spec/lib/code_teams_spec.rb
+++ b/spec/lib/code_teams_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Teams' do
+RSpec.describe CodeTeams do
   let(:team_yml) do
     <<~YML.strip
       name: My Team
@@ -7,14 +7,14 @@ RSpec.describe 'Teams' do
 
   before do
     write_file('config/teams/my_team.yml', team_yml)
-    Teams.bust_caches!
-    allow(Teams::Plugin).to receive(:registry).and_return({})
+    CodeTeams.bust_caches!
+    allow(CodeTeams::Plugin).to receive(:registry).and_return({})
   end
 
   describe '.all' do
     it 'correctly parses the team files' do
-      expect(Teams.all.count).to eq 1
-      team = Teams.all.first
+      expect(CodeTeams.all.count).to eq 1
+      team = CodeTeams.all.first
       expect(team.name).to eq 'My Team'
       expect(team.raw_hash['name']).to eq 'My Team'
       expect(team.config_yml).to eq 'config/teams/my_team.yml'
@@ -29,8 +29,8 @@ RSpec.describe 'Teams' do
       end
 
       it 'spits out a helpful error message' do
-        expect { Teams.all }.to raise_error do |e|
-          expect(e).to be_a Teams::IncorrectPublicApiUsageError
+        expect { CodeTeams.all }.to raise_error do |e|
+          expect(e).to be_a CodeTeams::IncorrectPublicApiUsageError
           expect(e.message).to eq('The YML in config/teams/my_team.yml has a syntax error!')
         end
       end
@@ -38,7 +38,7 @@ RSpec.describe 'Teams' do
   end
 
   describe 'validation_errors' do
-    subject(:validation_errors) { Teams.validation_errors(Teams.all) }
+    subject(:validation_errors) { CodeTeams.validation_errors(CodeTeams.all) }
 
     context 'there is one definition for all teams' do
       it 'has no errors' do
@@ -63,8 +63,8 @@ RSpec.describe 'Teams' do
 
   describe '==' do
     it 'handles nil correctly' do
-      expect(Teams.all.first == nil).to eq false # rubocop:disable Style/NilComparison
-      expect(nil == Teams.all.first).to eq false
+      expect(CodeTeams.all.first == nil).to eq false # rubocop:disable Style/NilComparison
+      expect(nil == CodeTeams.all.first).to eq false
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'bundler/setup'
 require 'pry'
-require 'teams'
+require 'code_teams'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/teams.gemspec
+++ b/teams.gemspec
@@ -5,13 +5,13 @@ Gem::Specification.new do |spec|
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for declaring and querying engineering teams'
   spec.description = 'A low-dependency gem for declaring and querying engineering teams'
-  spec.homepage      = 'https://github.com/bigrails/bigrails-teams'
+  spec.homepage      = 'https://github.com/rubyatscale/bigrails-teams'
   spec.license       = 'MIT'
 
   if spec.respond_to?(:metadata)
     spec.metadata['homepage_uri'] = spec.homepage
-    spec.metadata['source_code_uri'] = 'https://github.com/bigrails/bigrails-teams'
-    spec.metadata['changelog_uri'] = 'https://github.com/bigrails/bigrails-teams/releases'
+    spec.metadata['source_code_uri'] = 'https://github.com/rubyatscale/bigrails-teams'
+    spec.metadata['changelog_uri'] = 'https://github.com/rubyatscale/bigrails-teams/releases'
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   else
     raise 'RubyGems 2.0 or newer is required to protect against ' \

--- a/teams.gemspec
+++ b/teams.gemspec
@@ -1,17 +1,17 @@
 Gem::Specification.new do |spec|
-  spec.name          = 'bigrails-teams'
+  spec.name          = 'code_teams'
   spec.version       = '0.1.1'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for declaring and querying engineering teams'
   spec.description = 'A low-dependency gem for declaring and querying engineering teams'
-  spec.homepage      = 'https://github.com/rubyatscale/bigrails-teams'
+  spec.homepage      = 'https://github.com/rubyatscale/code_teams'
   spec.license       = 'MIT'
 
   if spec.respond_to?(:metadata)
     spec.metadata['homepage_uri'] = spec.homepage
-    spec.metadata['source_code_uri'] = 'https://github.com/rubyatscale/bigrails-teams'
-    spec.metadata['changelog_uri'] = 'https://github.com/rubyatscale/bigrails-teams/releases'
+    spec.metadata['source_code_uri'] = 'https://github.com/rubyatscale/code_teams'
+    spec.metadata['changelog_uri'] = 'https://github.com/rubyatscale/code_teams/releases'
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   else
     raise 'RubyGems 2.0 or newer is required to protect against ' \


### PR DESCRIPTION
Resolves #4.

This changes the major namespace of this gem to be `CodeTeams` rather than `Teams`. It also changes the name of the gem to `code_teams`. Once this lands, I will also rename the repository to `code_teams` accordingly.

This of course requires a major version bump since the user will need to use a different gem and use differenet API. I will include a "migration guide" in the release notes.
